### PR TITLE
Use std::format_string in the logger methods to check the format at compile time

### DIFF
--- a/src/lib/es3n1n/common/logger.hpp
+++ b/src/lib/es3n1n/common/logger.hpp
@@ -204,18 +204,16 @@ namespace logger {
         }
     } // namespace detail
 
-#define MAKE_LOGGER_METHOD(fn_name, prefix, color_fg, color_bg)                           \
-    template <std::uint8_t Indentation = 0, detail::str_view_t Str, typename... Args>     \
-    inline void fn_name(const Str fmt, Args... args) noexcept {                           \
-        std::conditional_t<detail::wchar_str_view_t<Str>, std::wstring, std::string> msg; \
-                                                                                          \
-        if constexpr (detail::wchar_str_view_t<Str>) {                                    \
-            msg = std::vformat(fmt, std::make_wformat_args(std::forward<Args>(args)...)); \
-        } else {                                                                          \
-            msg = std::vformat(fmt, std::make_format_args(std::forward<Args>(args)...));  \
-        }                                                                                 \
-                                                                                          \
-        detail::log_line(Indentation, prefix, (color_fg).fg, (color_bg).bg, msg);         \
+#define MAKE_LOGGER_METHOD(fn_name, prefix, color_fg, color_bg)                          \
+    template <std::uint8_t Indentation = 0, typename... Args>                            \
+    inline void fn_name(const std::format_string<Args...> fmt, Args... args) noexcept {  \
+        auto msg = std::vformat(fmt.get(), std::make_format_args(args...));              \
+        detail::log_line(Indentation, prefix, (color_fg).fg, (color_bg).bg, msg);        \
+    }                                                                                    \
+    template <std::uint8_t Indentation = 0, typename... Args>                            \
+    inline void fn_name(const std::wformat_string<Args...> fmt, Args... args) noexcept { \
+        auto msg = std::vformat(fmt.get(), std::make_wformat_args(args...));             \
+        detail::log_line(Indentation, prefix, (color_fg).fg, (color_bg).bg, msg);        \
     }
 
     MAKE_LOGGER_METHOD(debug, "debug", detail::colors::BRIGHT_WHITE, detail::colors::NO_COLOR)


### PR DESCRIPTION
## Summary

This PR updates the logger methods to use `std::format_string` and `std::wformat_string` to enable compile-time format checks, preventing runtime exceptions due to format string mismatches.

## Changes

- Modified `MAKE_LOGGER_METHOD` macro to accept `std::format_string` and `std::wformat_string`.
- Updated the logger method implementations to use the format strings directly, leveraging compile-time checks provided by the standard library.

## Justification

The use of `std::format_string` and `std::wformat_string` ensures that format string mismatches are caught at compile time, improving the robustness of the logger.

## Update Example
```cpp
int main() {
    logger::debug("msg with {} brackets", 1);
    logger::debug(L"wide msg with {} brackets", 1);

    // These lines will cause compile-time errors due to format string mismatch
    logger::debug("this should be ct error now {}");
    logger::debug("this should be ct error now", 1);
}
```