### PR TITLE
fix incorrect include for std::numeric_limits

### DIFF
--- a/src/lib/es3n1n/common/platform.hpp
+++ b/src/lib/es3n1n/common/platform.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <numeric>
+#include <limits>
 
 /// Systems
 ///


### PR DESCRIPTION
referring to "cppreference", the implementation of std::numeric_limits is in the "limits" header, not "numeric". currently the numeric header is included, which causes an error at compile time on either compiler, since std::numeric_limits is not defined