### PR TITLE
replace various comparison operators with spaceship-operator

### DIFF
--- a/src/lib/es3n1n/common/memory/address.hpp
+++ b/src/lib/es3n1n/common/memory/address.hpp
@@ -167,16 +167,16 @@ namespace memory {
             return static_cast<bool>(address_);
         }
 
-#define MATH_OPERATOR(type, operation) /* NOLINT(ppcoreguidelines-macro-usage) */                          \
-    constexpr type operator operation(const address& rhs) const { /* NOLINT(bugprone-macro-parentheses) */ \
-        return static_cast<type>(address_ operation rhs.address_);                                         \
-    }
+        // \note: @annihilatorq: intentionally left with no return type, see #11
+        constexpr auto operator<=>(const address&) const = default;
 
-        auto operator<=>(const address&) const = default;
-        MATH_OPERATOR(address, +)
-        MATH_OPERATOR(address, -)
+        constexpr address operator+(const address& rhs) const {
+            return static_cast<address>(address_ + rhs.address_);
+        }
 
-#undef MATH_OPERATOR
+        constexpr address operator-(const address& rhs) const {
+            return static_cast<address>(address_ - rhs.address_);
+        }
 
     private:
         std::uintptr_t address_ = 0;

--- a/src/lib/es3n1n/common/memory/address.hpp
+++ b/src/lib/es3n1n/common/memory/address.hpp
@@ -172,12 +172,7 @@ namespace memory {
         return static_cast<type>(address_ operation rhs.address_);                                         \
     }
 
-        MATH_OPERATOR(bool, ==)
-        MATH_OPERATOR(bool, !=)
-        MATH_OPERATOR(bool, >)
-        MATH_OPERATOR(bool, <)
-        MATH_OPERATOR(bool, <=)
-        MATH_OPERATOR(bool, >=)
+        auto operator<=>(const address&) const = default;
         MATH_OPERATOR(address, +)
         MATH_OPERATOR(address, -)
 

--- a/src/tests/memory/address.cpp
+++ b/src/tests/memory/address.cpp
@@ -56,3 +56,37 @@ TEST(address, aligns) {
     EXPECT_EQ(memory::address(0x2234).align_up(0x1000), 0x3000);
     EXPECT_EQ(memory::address(0x2000).align_up(0x1000), 0x2000);
 }
+
+TEST(address, operators) {
+    memory::address addr1(0x1000);
+    memory::address addr2(0x2000);
+    memory::address addr3(0x1000);
+
+    EXPECT_EQ((addr1 + addr2).inner(), 0x3000);
+    EXPECT_EQ((addr2 - addr1).inner(), 0x1000);
+
+    EXPECT_TRUE(addr1 < addr2);
+    EXPECT_TRUE(addr2 > addr1);
+    EXPECT_TRUE(addr1 <= addr3);
+    EXPECT_TRUE(addr1 >= addr3);
+
+    EXPECT_TRUE(addr1 == addr3);
+    EXPECT_TRUE(addr1 != addr2);
+
+    EXPECT_TRUE(static_cast<bool>(addr1));
+    EXPECT_FALSE(static_cast<bool>(memory::address(nullptr)));
+    EXPECT_EQ(static_cast<std::uintptr_t>(addr1), 0x1000);
+}
+
+TEST(address, casting) {
+    memory::address addr(0x12345678);
+
+    EXPECT_EQ(addr.cast<std::uint32_t>(), static_cast<std::uint32_t>(0x12345678));
+    EXPECT_EQ(addr.cast<std::uint64_t>(), static_cast<std::uint64_t>(0x12345678));
+    EXPECT_EQ(addr.cast<std::int32_t>(), static_cast<std::int32_t>(0x12345678));
+
+    EXPECT_EQ(addr.as<std::uintptr_t>(), static_cast<std::uintptr_t>(0x12345678));
+
+    int* ptr = addr.as<int*>();
+    EXPECT_EQ(reinterpret_cast<std::uintptr_t>(ptr), static_cast<std::uintptr_t>(0x12345678));
+}


### PR DESCRIPTION
i decided to use `auto operator<=>(const address&) const = default;` instead of adding the `<=>` operator through the `MATH_OPERATOR` macro to ensure automatic generation of the `==` and `!=` operators. when specifying a particular return type like std::strong_ordering in the macro, compiler doesn't automatically generate `==` and `!=` due to the separation of comparison categories in cpp20. using `auto` with `default` allows the compiler to deduce the return type and generate all necessary comparison operators, which increases code simplicity and reduces redundancy