### PR TITLE
fix C28020 warning

### DIFF
--- a/src/lib/es3n1n/common/hashes/crc.hpp
+++ b/src/lib/es3n1n/common/hashes/crc.hpp
@@ -19,7 +19,9 @@ namespace hashes {
                 for (std::size_t bit = 0; bit < CHAR_BIT; bit++) {
                     crc = (crc >> 1) ^ ((crc & 1) * kCrc32Polynomial);
                 }
-                result[i] = crc;
+                // \note: @annihilatorq: .at() is used to avoid weird warning C28020, when static
+                // analyzer thinks the index may go out of bounds when using [], despite clear limits
+                result.at( i ) = crc;
             }
             return result;
         }();

--- a/src/lib/es3n1n/common/hashes/crc.hpp
+++ b/src/lib/es3n1n/common/hashes/crc.hpp
@@ -21,7 +21,7 @@ namespace hashes {
                 }
                 // \note: @annihilatorq: .at() is used to avoid weird warning C28020, when static
                 // analyzer thinks the index may go out of bounds when using [], despite clear limits
-                result.at( i ) = crc;
+                result.at(i) = crc;
             }
             return result;
         }();


### PR DESCRIPTION
.at() is used to avoid warning C28020, where the static analyzer incorrectly flags possible out-of-bounds access with [] despite clear loop limits (terminating at 254 iteration)